### PR TITLE
ET-3633 fix package export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "xayn_js_sdk",
+  "name": "xayn_ts_sdk",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "dist/xayn_sdk.js",
   "scripts": {
     "test": "mocha -r ts-node/register -r amd-loader 'src/**/*.test.ts'",
     "build": "tsc"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xaynetwork/xayn_js_sdk.git"
+    "url": "git+https://github.com/xaynetwork/xayn_ts_sdk.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/xaynetwork/xayn_js_sdk/issues"
+    "url": "https://github.com/xaynetwork/xayn_ts_sdk/issues"
   },
-  "homepage": "https://github.com/xaynetwork/xayn_js_sdk#readme",
+  "homepage": "https://github.com/xaynetwork/xayn_ts_sdk#readme",
   "devDependencies": {
     "@types/chai": "^4.3.4",
     "@types/mocha": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xayn_ts_sdk",
   "version": "1.0.0",
   "description": "",
-  "main": "dist/xayn_sdk.js",
+  "main": "dist/index.js",
   "scripts": {
     "test": "mocha -r ts-node/register -r amd-loader 'src/**/*.test.ts'",
     "build": "tsc"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2015",  
+    "target": "es2015",
     "declaration": true,                                 /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     "lib": ["es6", "DOM"],                               /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
@@ -47,9 +47,9 @@
     /* Emit */
     // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */ 
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    "outFile": "./dist/xayn_sdk.js",                     /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */ 
+    "outFile": "./dist/xayn_sdk.js",                     /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./dist",                               /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "AMD",                                     /* Specify what module code is generated. */
+    "module": "es2015",                                     /* Specify what module code is generated. */
     "rootDir": "src",                                    /* Specify the root folder within your source files. */
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
@@ -49,8 +49,8 @@
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    "outFile": "./dist/xayn_sdk.js",                     /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./dist",                               /* Specify an output folder for all emitted files. */
+    // "outFile": "./dist/xayn_sdk.js",                     /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    "outDir": "./dist",                               /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */


### PR DESCRIPTION
- make sure `xayn_ts_sdk` is used everywhere
- point `main` to the module entry point
- some whitespace errors my ide auto fixed
- switch from AMD to ECMAScript module
  - as it's much easier to use with modern web project tooling; the standard format for js/ts modules by now and with how modern js/ts projects are done there is close to no benefit to use older standards like AMD anymore
 - we might want to provide additional alternative module formats including AMD in  the future in case our customers use older web technology and need it, but ECMAScript modules should be the "default" format IMHO