### PR TITLE
ET-3702 fix type mismatch

### DIFF
--- a/src/client/model/personalized_document_data.ts
+++ b/src/client/model/personalized_document_data.ts
@@ -2,6 +2,6 @@ export class PersonalizedDocumentData {
   constructor(
     readonly id: string,
     readonly score: number,
-    readonly properties?: Map<string, any>
+    readonly properties?: Record<string, any>
   ) {}
 }


### PR DESCRIPTION
# Summary

`Map<>` => `Record`

 - `Map` is a js map type and expects methods like `clear()` 
 - `Record` is the js object with just data
 
# References

- ET-3702