### PR TITLE
ET-3703 url handling improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ To create the server-side SDK version, simply use
 
 ```typescript
 const sdk = new Server({
-  endpoint: {your_endpoint},
-  environment: {your_environment}, // eg default
+  endpoint: {your_endpoint_url}, //e.g. https://some.domain.invalid/default
   token: {your_token},
 });
 ```
@@ -63,7 +62,7 @@ const result = await sdk.ingest({
             }
         ),
     ],
-}); /// returns true if successful
+});
 ```
 ### Update a document's properties
 This example updates the properties for ```document_id_a``` and overwrites the image.
@@ -117,15 +116,14 @@ To create the client-side SDK version, simply use
 ```typescript
 const sdk = new Client({
   endpoint: {your_endpoint},
-  environment: {your_environment}, // eg default
   token: {your_token},
-  userId: {any_user}, // eg John_Doe
+  userId: {any_user}, // eg "35940aa3-95ad-4dc2-9a2b-000eed135e9b"
 });
 ```
 ### Like a single document
 Marks the given document as "liked" for this user.
 ```typescript
-await sdk.likeDocument({ documentId: "test_d" }); // returns true if successful
+await sdk.likeDocument({ documentId: "test_d" });
 ```
 ### Fetch personalized documents
 Fetches personalized documents for this user.\

--- a/src/__test__/a_server.test.ts
+++ b/src/__test__/a_server.test.ts
@@ -3,12 +3,10 @@ import "mocha";
 import { IngestedDocument, Server } from "../index";
 
 const endpoint = "{ENDPOINT}";
-const environment = "default";
 const token = "{TOKEN}";
 
 const server = new Server({
   endpoint: endpoint,
-  environment: environment,
   token: token,
 });
 

--- a/src/__test__/b_client.test.ts
+++ b/src/__test__/b_client.test.ts
@@ -3,13 +3,11 @@ import "mocha";
 import { Client } from "../index";
 
 const endpoint = "{ENFPOINT}";
-const environment = "default";
 const token = "{TOKEN}";
 const userId = "test";
 
 const client = new Client({
   endpoint: endpoint,
-  environment: environment,
   token: token,
   userId: userId,
 });

--- a/src/client/base_client.ts
+++ b/src/client/base_client.ts
@@ -4,19 +4,16 @@ export type BaseClientCtr = _Constructor<BaseClient>;
 
 export class BaseClient {
   readonly endpoint: URL;
-  readonly environment: string;
   readonly token: string;
   readonly userId: string;
 
   constructor(args: {
     readonly token: string;
     readonly endpoint: string | URL;
-    readonly environment: string;
     readonly userId: string;
   }) {
     this.token = args.token;
-    this.endpoint = args.endpoint instanceof URL ? args.endpoint : new URL(args.endpoint);
-    this.environment = args.environment;
+    this.endpoint = new URL(args.endpoint);
     this.userId = args.userId;
   }
 }

--- a/src/client/base_client.ts
+++ b/src/client/base_client.ts
@@ -10,12 +10,12 @@ export class BaseClient {
 
   constructor(args: {
     readonly token: string;
-    readonly endpoint: string;
+    readonly endpoint: string | URL;
     readonly environment: string;
     readonly userId: string;
   }) {
     this.token = args.token;
-    this.endpoint = new URL(args.endpoint);
+    this.endpoint = args.endpoint instanceof URL ? args.endpoint : new URL(args.endpoint);
     this.environment = args.environment;
     this.userId = args.userId;
   }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -6,6 +6,6 @@ export * from "./model/model";
 export const Client = PersonalizedDocumentMixin(LikeDocumentMixin(BaseClient));
 
 function _ts_type_helper() {
-    return new Client({ token: '', endpoint: '', environment: '', userId: '' });
+    return new Client({ token: '', endpoint: '', userId: '' });
 }
 export type Client = ReturnType<typeof _ts_type_helper>;

--- a/src/client/mixins/interaction.ts
+++ b/src/client/mixins/interaction.ts
@@ -1,3 +1,4 @@
+import { withAdditionalPathSegments } from "../../utils";
 import { BaseClientCtr } from "../base_client";
 import {
   UserInteractionError,
@@ -12,10 +13,8 @@ import {
 export function LikeDocumentMixin<TBase extends BaseClientCtr>(Base: TBase) {
   return class extends Base {
     async likeDocument(args: { documentId: string }): Promise<boolean> {
-      const uri = new URL(
-        `${this.environment}/users/${this.userId}/interactions`,
-        this.endpoint
-      );
+      const uri = withAdditionalPathSegments(this.endpoint, ["users", this.userId, "interactions"]);
+
       const payload = JSON.stringify(
         new UserInteractionRequest([
           new UserInteractionData(

--- a/src/client/mixins/personalized_documents.ts
+++ b/src/client/mixins/personalized_documents.ts
@@ -1,3 +1,4 @@
+import { withAdditionalPathSegments } from "../../utils";
 import { BaseClientCtr } from "../base_client";
 import {
   PersonalizedDocumentsError,
@@ -18,10 +19,7 @@ export function PersonalizedDocumentMixin<TBase extends BaseClientCtr>(
         throw new Error("`count` should be a value between 1 and 100");
       }
 
-      const uri = new URL(
-        `${this.environment}/users/${this.userId}/personalized_documents`,
-        this.endpoint
-      );
+      const uri = withAdditionalPathSegments(this.endpoint, ["users", this.userId, "personalized_documents"]);
 
       uri.searchParams.append("count", count.toString());
 

--- a/src/server/base_server.ts
+++ b/src/server/base_server.ts
@@ -4,16 +4,13 @@ export type BaseServerCtr = _Constructor<BaseServer>;
 
 export class BaseServer {
   readonly endpoint: URL;
-  readonly environment: string;
   readonly token: string;
 
   constructor(args: {
     readonly token: string;
-    readonly endpoint: string;
-    readonly environment: string;
+    readonly endpoint: string | URL;
   }) {
     this.token = args.token;
     this.endpoint = new URL(args.endpoint);
-    this.environment = args.environment;
   }
 }

--- a/src/server/mixins/delete_documents.ts
+++ b/src/server/mixins/delete_documents.ts
@@ -1,13 +1,11 @@
+import { withAdditionalPathSegments } from "../../utils";
 import { BaseServerCtr } from "../base_server";
 import { DeleteDocumentsRequest } from "../model/delete_documents_request";
 
 export function DeleteDocumentsMixin<TBase extends BaseServerCtr>(Base: TBase) {
   return class extends Base {
     async delete(args: { documentId: string }): Promise<boolean> {
-      const uri = new URL(
-        `${this.environment}/documents/${args.documentId}`,
-        this.endpoint
-      );
+      const uri = withAdditionalPathSegments(this.endpoint, ["documents", args.documentId]);
       const response = await fetch(uri, {
         method: "DELETE",
         headers: {
@@ -29,7 +27,7 @@ export function DeleteDocumentsMixin<TBase extends BaseServerCtr>(Base: TBase) {
     }
 
     async deleteAll(args: { documents: Array<string> }): Promise<boolean> {
-      const uri = new URL(`${this.environment}/documents`, this.endpoint);
+      const uri = withAdditionalPathSegments(this.endpoint, ["documents"]);
       const payload = JSON.stringify(
         new DeleteDocumentsRequest(args.documents)
       );

--- a/src/server/mixins/document_properties.ts
+++ b/src/server/mixins/document_properties.ts
@@ -1,3 +1,4 @@
+import { withAdditionalPathSegments } from "../../utils";
 import { BaseServerCtr } from "../base_server";
 import { DocumentPropertiesRequest } from "../model/document_properties_request";
 
@@ -6,10 +7,7 @@ export function DocumentPropertiesMixin<TBase extends BaseServerCtr>(
 ) {
   return class extends Base {
     async getProperties(args: { documentId: string }): Promise<any> {
-      const uri = new URL(
-        `${this.environment}/documents/${args.documentId}/properties`,
-        this.endpoint
-      );
+      const uri = withAdditionalPathSegments(this.endpoint, ["documents", args.documentId, "properties"]);
       const response = await fetch(uri, {
         method: "GET",
         headers: {
@@ -36,10 +34,7 @@ export function DocumentPropertiesMixin<TBase extends BaseServerCtr>(
       documentId: string;
       properties: Object;
     }): Promise<boolean> {
-      const uri = new URL(
-        `${this.environment}/documents/${args.documentId}/properties`,
-        this.endpoint
-      );
+      const uri = withAdditionalPathSegments(this.endpoint,["documents", args.documentId, "properties"]);
       const payload = JSON.stringify(
         new DocumentPropertiesRequest(args.properties)
       );
@@ -68,10 +63,7 @@ export function DocumentPropertiesMixin<TBase extends BaseServerCtr>(
     }
 
     async deleteProperties(args: { documentId: string }): Promise<boolean> {
-      const uri = new URL(
-        `${this.environment}/documents/${args.documentId}/properties`,
-        this.endpoint
-      );
+      const uri = withAdditionalPathSegments(this.endpoint, ["documents", args.documentId, "properties"]);
       const response = await fetch(uri, {
         method: "DELETE",
         headers: {

--- a/src/server/mixins/documents.ts
+++ b/src/server/mixins/documents.ts
@@ -1,3 +1,4 @@
+import { withAdditionalPathSegments } from "../../utils";
 import { BaseServerCtr } from "../base_server";
 import {
   IngestionError,
@@ -15,7 +16,7 @@ export function DocumentsMixin<TBase extends BaseServerCtr>(Base: TBase) {
       var _ingest = async (args: {
         documents: Array<IngestedDocument>;
       }): Promise<boolean> => {
-        const uri = new URL(`${this.environment}/documents`, this.endpoint);
+        const uri = withAdditionalPathSegments(this.endpoint, ['documents' ]);
         const payload = JSON.stringify(new IngestionRequest(args.documents));
         const response = await fetch(uri, {
           method: "POST",

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -10,6 +10,6 @@ export const Server = DocumentPropertiesMixin(
 );
 
 function _ts_type_helper() {
-    return new Server({ token: '', endpoint: '', environment: '', });
+    return new Server({ token: '', endpoint: '', });
 }
 export type Server = ReturnType<typeof _ts_type_helper>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,16 @@
+
+
+export function withAdditionalPathSegments(url: string | URL, segments: string[]): URL {
+    let extended = new URL(url);
+    extended.pathname =
+        // make sure not not have a //
+        [trimEndSlash(extended.pathname)]
+            // encode and add all segment
+            .concat(segments.map((segment) => encodeURIComponent(segment)))
+            .join('/');
+    return extended;
+}
+
+function trimEndSlash(path: string): string {
+    return path.endsWith('/') ? path.substring(0, path.length - 1) : path;
+}


### PR DESCRIPTION
# Summary

- Make sure to uri encode components like userId or documentId as necessary (e.g. encode a `\` in a `documentId`).
- Also extend the path of the endpoint URL with the endpoint specific segments instead of replacing it.
- As it was easier to remove environment then to adapt it after the previous changes I removed it. 

# Follow Up

- this will be followed up with a PR adding minimal CI support, consistent formatting and tests (and the tests for `src/utils.ts` to the repo) 

# References

- ET-3703